### PR TITLE
Improve ALNS evaluation order

### DIFF
--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -263,12 +263,12 @@ class ALNS(CallbackMixin):
             The weight index to use when updating the operator weights.
         """
         if criterion.accept(self._rnd_state, best, current, candidate):
-            current = candidate
-
             if candidate.objective() < current.objective():
                 weight = WeightIndex.IS_BETTER
             else:
                 weight = WeightIndex.IS_ACCEPTED
+
+            current = candidate
         else:
             weight = WeightIndex.IS_REJECTED
 

--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -179,15 +179,10 @@ class ALNS(CallbackMixin):
             r_name, r_operator = self.repair_operators[r_idx]
             candidate = r_operator(destroyed, self._rnd_state)
 
-            current, weight_idx = self._consider_candidate(best, current,
-                                                           candidate, criterion)
-
-            if current.objective() < best.objective():
-                if self.has_callback(CallbackFlag.ON_BEST):
-                    callback = self.callback(CallbackFlag.ON_BEST)
-                    current = callback(current, self._rnd_state)
-
-                best = current
+            best, current, weight_idx = self._consider_candidate(best,
+                                                                 current,
+                                                                 candidate,
+                                                                 criterion)
 
             # The weights are updated as convex combinations of the current
             # weight and the update parameter. See eq. (2), p. 12.
@@ -261,20 +256,36 @@ class ALNS(CallbackMixin):
         Returns
         -------
         State
-            The new state.
+            The (possibly new) best state.
+        State
+            The (possibly new) current state.
         int
             The weight index to use when updating the operator weights.
         """
-        if candidate.objective() < best.objective():
-            return candidate, WeightIndex.IS_BEST
-
-        if candidate.objective() < current.objective():
-            return candidate, WeightIndex.IS_BETTER
-
         if criterion.accept(self._rnd_state, best, current, candidate):
-            return candidate, WeightIndex.IS_ACCEPTED
+            current = candidate
 
-        return current, WeightIndex.IS_REJECTED
+            if candidate.objective() < current.objective():
+                weight = WeightIndex.IS_BETTER
+            else:
+                weight = WeightIndex.IS_ACCEPTED
+        else:
+            weight = WeightIndex.IS_REJECTED
+
+        if candidate.objective() < best.objective():
+            # Is a new global best, so we might want to do something to further
+            # improve the solution.
+            if self.has_callback(CallbackFlag.ON_BEST):
+                callback = self.callback(CallbackFlag.ON_BEST)
+                candidate = callback(candidate, self._rnd_state)
+
+            # Global best solution becomes the new starting point for further
+            # iterations.
+            return candidate, candidate, WeightIndex.IS_BEST
+
+        # Best has not been updated if we get here, but the current state might
+        # have (if the candidate was accepted).
+        return best, current, weight
 
     def _validate_parameters(self, weights, operator_decay, iterations):
         """

--- a/alns/tests/test_alns.py
+++ b/alns/tests/test_alns.py
@@ -268,7 +268,7 @@ def test_fixed_seed_outcomes():
     Tests if fixing a seed results in deterministic outcomes even when using a
     'random' acceptance criterion (here SA).
     """
-    outcomes = [0.00469, 0.00011, 0.04312]
+    outcomes = [0.01171, 0.00011, 0.01025]
 
     for seed, desired in enumerate(outcomes):                   # idx is seed
         alns = get_alns_instance(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 MAJOR = 1
 MINOR = 2
-MAINTENANCE = 3
+MAINTENANCE = 4
 MODIFIER = ""
 
 VERSION = "{0}.{1}.{2}{3}".format(MAJOR, MINOR, MAINTENANCE, MODIFIER)


### PR DESCRIPTION
This is more in line with the reference implementation given in Ropke and Pisinger (2019), and has the added benefit that it guarantees accept() is called for each iteration. That's nice if you want to estimate e.g. the step parameter for simulated annealing based on the number of iterations.