### PR TITLE
Unofficial support for np 1.17 rnd.Generator

### DIFF
--- a/alns/criteria/SimulatedAnnealing.py
+++ b/alns/criteria/SimulatedAnnealing.py
@@ -82,4 +82,11 @@ class SimulatedAnnealing(AcceptanceCriterion):
                                                              self.step,
                                                              self.method))
 
-        return probability >= rnd.random_sample()
+        # TODO the following is in preparation of the new numpy Generator
+        #  interface, which deprecates random_sample() in favour of random().
+        #  ALNS does not yet formally support Generators, but unofficially it
+        #  should work in most cases.
+        try:
+            return probability >= rnd.random()
+        except AttributeError:
+            return probability >= rnd.random_sample()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 MAJOR = 1
 MINOR = 2
-MAINTENANCE = 4
+MAINTENANCE = 5
 MODIFIER = ""
 
 VERSION = "{0}.{1}.{2}{3}".format(MAJOR, MINOR, MAINTENANCE, MODIFIER)


### PR DESCRIPTION
This is a quick fix to making [Generators](https://docs.scipy.org/doc/numpy/reference/random/generator.html#numpy.random.Generator) work. Eventually, this should be supported in a nicer format.