### PR TITLE
Stopping criteria 

### DIFF
--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -160,7 +160,9 @@ class ALNS:
         Operational Research*, 171: 750–775, 2006.
         """
         if len(self.destroy_operators) == 0 or len(self.repair_operators) == 0:
-            raise ValueError("Missing at least one destroy or repair operator.")
+            raise ValueError(
+                "Missing at least one destroy or repair operator."
+            )
 
         curr = best = initial_solution
 
@@ -177,7 +179,9 @@ class ALNS:
             destroyed = d_operator(curr, self._rnd_state, **kwargs)
             cand = r_operator(destroyed, self._rnd_state, **kwargs)
 
-            best, curr, s_idx = self._eval_cand(crit, best, curr, cand, **kwargs)
+            best, curr, s_idx = self._eval_cand(
+                crit, best, curr, cand, **kwargs
+            )
 
             weight_scheme.update_weights(d_idx, r_idx, s_idx)
 
@@ -203,7 +207,12 @@ class ALNS:
         self._on_best = func
 
     def _eval_cand(
-        self, crit: AcceptanceCriterion, best: State, curr: State, cand: State, **kwargs
+        self,
+        crit: AcceptanceCriterion,
+        best: State,
+        curr: State,
+        cand: State,
+        **kwargs,
     ) -> Tuple[State, State, int]:
         """
         Considers the candidate solution by comparing it against the best and

--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -170,7 +170,7 @@ class ALNS:
         stats.collect_objective(initial_solution.objective())
         stats.collect_runtime(time.perf_counter())
 
-        while not stop(rnd, best, curr):
+        while not stop(self._rnd_state, best, curr):
             d_idx, r_idx = weight_scheme.select_operators(self._rnd_state)
 
             d_name, d_operator = self.destroy_operators[d_idx]

--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -170,7 +170,7 @@ class ALNS:
         stats.collect_objective(initial_solution.objective())
         stats.collect_runtime(time.perf_counter())
 
-        while not stop(best, curr):
+        while not stop(rnd, best, curr):
             d_idx, r_idx = weight_scheme.select_operators(self._rnd_state)
 
             d_name, d_operator = self.destroy_operators[d_idx]

--- a/alns/Statistics.py
+++ b/alns/Statistics.py
@@ -25,6 +25,20 @@ class Statistics:
         return np.array(self._objectives)
 
     @property
+    def start_time(self) -> float:
+        """
+        Return the reference start time to compute the runtimes.
+        """
+        return self._runtimes[0]
+
+    @property
+    def total_runtime(self) -> float:
+        """
+        Return the total runtime (in seconds).
+        """
+        return self._runtimes[-1] - self._runtimes[0]
+
+    @property
     def runtimes(self) -> np.ndarray:
         """
         Returns an array of iteration run times (in seconds).

--- a/alns/stopping_criteria/MaxIterations.py
+++ b/alns/stopping_criteria/MaxIterations.py
@@ -5,7 +5,7 @@ from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
 
 class MaxIterations(StoppingCriterion):
-    def __init__(self, max_iterations: int) -> None:
+    def __init__(self, max_iterations: int):
         """
         Criterion that stops after a maximum number of iterations.
         """
@@ -19,11 +19,7 @@ class MaxIterations(StoppingCriterion):
     def max_iterations(self) -> int:
         return self._max_iterations
 
-    @property
-    def current_iteration(self) -> int:
-        return self._current_iteration
-
     def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         self._current_iteration += 1
 
-        return self.current_iteration > self.max_iterations
+        return self._current_iteration > self.max_iterations

--- a/alns/stopping_criteria/MaxIterations.py
+++ b/alns/stopping_criteria/MaxIterations.py
@@ -1,3 +1,4 @@
+from alns.State import State
 from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
 
@@ -20,7 +21,7 @@ class MaxIterations(StoppingCriterion):
     def current_iteration(self) -> int:
         return self._current_iteration
 
-    def __call__(self) -> bool:
+    def __call__(self, best: State, current: State) -> bool:
         self._current_iteration += 1
 
         return self.current_iteration > self.max_iterations

--- a/alns/stopping_criteria/MaxIterations.py
+++ b/alns/stopping_criteria/MaxIterations.py
@@ -1,3 +1,5 @@
+from numpy.random import RandomState
+
 from alns.State import State
 from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
@@ -21,7 +23,7 @@ class MaxIterations(StoppingCriterion):
     def current_iteration(self) -> int:
         return self._current_iteration
 
-    def __call__(self, best: State, current: State) -> bool:
+    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         self._current_iteration += 1
 
         return self.current_iteration > self.max_iterations

--- a/alns/stopping_criteria/MaxIterations.py
+++ b/alns/stopping_criteria/MaxIterations.py
@@ -1,0 +1,26 @@
+from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
+
+
+class MaxIterations(StoppingCriterion):
+    def __init__(self, max_iterations: int) -> None:
+        """
+        Criterion that stops after a maximum number of iterations.
+        """
+        if max_iterations < 0:
+            raise ValueError("Max iterations must be non-negative.")
+
+        self._max_iterations = max_iterations
+        self._current_iteration = 0
+
+    @property
+    def max_iterations(self) -> int:
+        return self._max_iterations
+
+    @property
+    def current_iteration(self) -> int:
+        return self._current_iteration
+
+    def __call__(self) -> bool:
+        self._current_iteration += 1
+
+        return self.current_iteration > self.max_iterations

--- a/alns/stopping_criteria/MaxRuntime.py
+++ b/alns/stopping_criteria/MaxRuntime.py
@@ -1,6 +1,7 @@
 import time
 
-from .StoppingCriterion import StoppingCriterion
+from alns.State import State
+from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
 
 class MaxRuntime(StoppingCriterion):
@@ -33,7 +34,7 @@ class MaxRuntime(StoppingCriterion):
 
         return self._start_runtime
 
-    def __call__(self) -> bool:
+    def __call__(self, best: State, current: State) -> bool:
         # Reverse evaluation order to ensure that start_runtime is called first.
         self._elapsed_runtime = -(self.start_runtime - time.perf_counter())
 

--- a/alns/stopping_criteria/MaxRuntime.py
+++ b/alns/stopping_criteria/MaxRuntime.py
@@ -1,0 +1,40 @@
+import time
+
+from .StoppingCriterion import StoppingCriterion
+
+
+class MaxRuntime(StoppingCriterion):
+    def __init__(self, max_runtime: int) -> None:
+        """
+        Criterion that stops after a maximum number of iterations.
+        """
+        if max_runtime < 0:
+            raise ValueError("Max iterations must be non-negative.")
+
+        self._max_runtime = max_runtime
+        self._elapsed_runtime = None
+        self._start_runtime = None
+
+    @property
+    def max_runtime(self) -> float:
+        return self._max_runtime
+
+    @property
+    def elapsed_runtime(self) -> float:
+        return self._elapsed_runtime
+
+    @property
+    def start_runtime(self) -> float:
+        """
+        Reference point to calculate the elapsed time.
+        """
+        if self._start_runtime is None:
+            self._start_runtime = time.perf_counter()
+
+        return self._start_runtime
+
+    def __call__(self) -> bool:
+        # Reverse evaluation order to ensure that start_runtime is called first.
+        self._elapsed_runtime = -(self.start_runtime - time.perf_counter())
+
+        return self.elapsed_runtime > self.max_runtime

--- a/alns/stopping_criteria/MaxRuntime.py
+++ b/alns/stopping_criteria/MaxRuntime.py
@@ -1,5 +1,6 @@
 import time
 
+from typing import Optional
 from numpy.random import RandomState
 
 from alns.State import State
@@ -7,7 +8,7 @@ from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
 
 class MaxRuntime(StoppingCriterion):
-    def __init__(self, max_runtime: int) -> None:
+    def __init__(self, max_runtime: float):
         """
         Criterion that stops after a specified maximum runtime.
         """
@@ -15,29 +16,14 @@ class MaxRuntime(StoppingCriterion):
             raise ValueError("Max runtime must be non-negative.")
 
         self._max_runtime = max_runtime
-        self._elapsed_runtime = None
-        self._start_runtime = None
+        self._start_runtime: Optional[float] = None
 
     @property
     def max_runtime(self) -> float:
         return self._max_runtime
 
-    @property
-    def elapsed_runtime(self) -> float:
-        return self._elapsed_runtime
-
-    @property
-    def start_runtime(self) -> float:
-        """
-        Reference point to calculate the elapsed time.
-        """
+    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         if self._start_runtime is None:
             self._start_runtime = time.perf_counter()
 
-        return self._start_runtime
-
-    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
-        # Reverse evaluation order to ensure that start_runtime is called first.
-        self._elapsed_runtime = -(self.start_runtime - time.perf_counter())
-
-        return self.elapsed_runtime > self.max_runtime
+        return time.perf_counter () - self._start_runtime > self.max_runtime

--- a/alns/stopping_criteria/MaxRuntime.py
+++ b/alns/stopping_criteria/MaxRuntime.py
@@ -1,5 +1,7 @@
 import time
 
+from numpy.random import RandomState
+
 from alns.State import State
 from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 
@@ -34,7 +36,7 @@ class MaxRuntime(StoppingCriterion):
 
         return self._start_runtime
 
-    def __call__(self, best: State, current: State) -> bool:
+    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         # Reverse evaluation order to ensure that start_runtime is called first.
         self._elapsed_runtime = -(self.start_runtime - time.perf_counter())
 

--- a/alns/stopping_criteria/MaxRuntime.py
+++ b/alns/stopping_criteria/MaxRuntime.py
@@ -7,10 +7,10 @@ from alns.stopping_criteria.StoppingCriterion import StoppingCriterion
 class MaxRuntime(StoppingCriterion):
     def __init__(self, max_runtime: int) -> None:
         """
-        Criterion that stops after a maximum number of iterations.
+        Criterion that stops after a specified maximum runtime.
         """
         if max_runtime < 0:
-            raise ValueError("Max iterations must be non-negative.")
+            raise ValueError("Max runtime must be non-negative.")
 
         self._max_runtime = max_runtime
         self._elapsed_runtime = None

--- a/alns/stopping_criteria/StoppingCriterion.py
+++ b/alns/stopping_criteria/StoppingCriterion.py
@@ -1,0 +1,22 @@
+from abc import ABC, abstractmethod
+
+from numpy.random import RandomState
+
+from alns.State import State
+
+
+class StoppingCriterion(ABC):
+    """
+    Base class from which to implement a stopping criterion.
+    """
+
+    @abstractmethod
+    def __call__(self) -> bool:
+        """
+        Determines whether to stop based on the implemented stopping criterion.
+
+        Returns
+        -------
+        Whether to stop the iteration (True), or not (False).
+        """
+        return NotImplemented

--- a/alns/stopping_criteria/StoppingCriterion.py
+++ b/alns/stopping_criteria/StoppingCriterion.py
@@ -11,9 +11,16 @@ class StoppingCriterion(ABC):
     """
 
     @abstractmethod
-    def __call__(self) -> bool:
+    def __call__(self, best: State, current: State) -> bool:
         """
         Determines whether to stop based on the implemented stopping criterion.
+
+        Parameters
+        ----------
+        best
+            The best solution state observed so far.
+        current
+            The current solution state.
 
         Returns
         -------

--- a/alns/stopping_criteria/StoppingCriterion.py
+++ b/alns/stopping_criteria/StoppingCriterion.py
@@ -11,12 +11,14 @@ class StoppingCriterion(ABC):
     """
 
     @abstractmethod
-    def __call__(self, best: State, current: State) -> bool:
+    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         """
         Determines whether to stop based on the implemented stopping criterion.
 
         Parameters
         ----------
+        rnd
+            May be used to draw random numbers from.
         best
             The best solution state observed so far.
         current

--- a/alns/stopping_criteria/__init__.py
+++ b/alns/stopping_criteria/__init__.py
@@ -1,0 +1,2 @@
+from .MaxIterations import MaxIterations
+from .StoppingCriterion import StoppingCriterion

--- a/alns/stopping_criteria/__init__.py
+++ b/alns/stopping_criteria/__init__.py
@@ -1,2 +1,3 @@
 from .MaxIterations import MaxIterations
+from .MaxRuntime import MaxRuntime
 from .StoppingCriterion import StoppingCriterion

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -1,7 +1,7 @@
 import pytest
 
 from numpy.testing import assert_, assert_raises
-from .. import MaxIterations
+from alns.stopping_criteria import MaxIterations
 
 
 @pytest.mark.parametrize("max_iterations", [-1, -42, -10000])

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -1,7 +1,9 @@
 import pytest
 
 from numpy.testing import assert_, assert_raises
+
 from alns.stopping_criteria import MaxIterations
+from alns.tests.states import Zero
 
 
 @pytest.mark.parametrize("max_iterations", [-1, -42, -10000])
@@ -40,7 +42,7 @@ def test_current_iteration(max_iterations: int, iterations: int):
     assert_(stop.current_iteration == 0)
 
     for _ in range(iterations):
-        stop()
+        stop(Zero(), Zero())
 
     assert_(stop.current_iteration == iterations)
 
@@ -49,14 +51,14 @@ def test_before_max_iterations():
     stop = MaxIterations(100)
 
     for _ in range(100):
-        assert_(not stop())
+        assert_(not stop(Zero(), Zero()))
 
 
 def test_after_max_iterations():
     stop = MaxIterations(100)
 
     for _ in range(100):
-        stop()
+        stop(Zero(), Zero())
 
     for _ in range(100):
-        assert_(stop())
+        assert_(stop(Zero(), Zero()))

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -1,5 +1,6 @@
 import pytest
 
+from numpy.random import RandomState
 from numpy.testing import assert_, assert_raises
 
 from alns.stopping_criteria import MaxIterations
@@ -40,27 +41,29 @@ def test_current_iteration(max_iterations: int, iterations: int):
     Test if the current iteration parameter is correctly set.
     """
     stop = MaxIterations(max_iterations)
-
+    rnd = RandomState()
     assert_(stop.current_iteration == 0)
 
     for _ in range(iterations):
-        stop(Zero(), Zero())
+        stop(rnd, Zero(), Zero())
 
     assert_(stop.current_iteration == iterations)
 
 
 def test_before_max_iterations():
     stop = MaxIterations(100)
+    rnd = RandomState(0)
 
     for _ in range(100):
-        assert_(not stop(Zero(), Zero()))
+        assert_(not stop(rnd, Zero(), Zero()))
 
 
 def test_after_max_iterations():
     stop = MaxIterations(100)
+    rnd = RandomState()
 
     for _ in range(100):
-        stop(Zero(), Zero())
+        stop(rnd, Zero(), Zero())
 
     for _ in range(100):
-        assert_(stop(Zero(), Zero()))
+        assert_(stop(rnd, Zero(), Zero()))

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -33,23 +33,6 @@ def test_max_iterations(max_iterations):
     assert stop.max_iterations == max_iterations
 
 
-@pytest.mark.parametrize(
-    "max_iterations, iterations", [(1, 0), (1000, 500), (0, 100)]
-)
-def test_current_iteration(max_iterations: int, iterations: int):
-    """
-    Test if the current iteration parameter is correctly set.
-    """
-    stop = MaxIterations(max_iterations)
-    rnd = RandomState()
-    assert_(stop.current_iteration == 0)
-
-    for _ in range(iterations):
-        stop(rnd, Zero(), Zero())
-
-    assert_(stop.current_iteration == iterations)
-
-
 def test_before_max_iterations():
     stop = MaxIterations(100)
     rnd = RandomState(0)

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -32,7 +32,9 @@ def test_max_iterations(max_iterations):
     assert stop.max_iterations == max_iterations
 
 
-@pytest.mark.parametrize("max_iterations, iterations", [(1, 0), (1000, 500), (0, 100)])
+@pytest.mark.parametrize(
+    "max_iterations, iterations", [(1, 0), (1000, 500), (0, 100)]
+)
 def test_current_iteration(max_iterations: int, iterations: int):
     """
     Test if the current iteration parameter is correctly set.

--- a/alns/stopping_criteria/tests/test_max_iterations.py
+++ b/alns/stopping_criteria/tests/test_max_iterations.py
@@ -1,0 +1,62 @@
+import pytest
+
+from numpy.testing import assert_, assert_raises
+from .. import MaxIterations
+
+
+@pytest.mark.parametrize("max_iterations", [-1, -42, -10000])
+def test_raise_negative_parameters(max_iterations: int):
+    """
+    Maximum iterations cannot be negative.
+    """
+    with assert_raises(ValueError):
+        MaxIterations(max_iterations)
+
+
+@pytest.mark.parametrize("max_iterations", [1, 42, 10000])
+def test_does_not_raise(max_iterations: int):
+    """
+    Valid parameters should not raise.
+    """
+    MaxIterations(max_iterations)
+
+
+@pytest.mark.parametrize("max_iterations", [1, 42, 10000])
+def test_max_iterations(max_iterations):
+    """
+    Test if the max iterations parameter is correctly set.
+    """
+    stop = MaxIterations(max_iterations)
+    assert stop.max_iterations == max_iterations
+
+
+@pytest.mark.parametrize("max_iterations, iterations", [(1, 0), (1000, 500), (0, 100)])
+def test_current_iteration(max_iterations: int, iterations: int):
+    """
+    Test if the current iteration parameter is correctly set.
+    """
+    stop = MaxIterations(max_iterations)
+
+    assert_(stop.current_iteration == 0)
+
+    for _ in range(iterations):
+        stop()
+
+    assert_(stop.current_iteration == iterations)
+
+
+def test_before_max_iterations():
+    stop = MaxIterations(100)
+
+    for _ in range(100):
+        assert_(not stop())
+
+
+def test_after_max_iterations():
+    stop = MaxIterations(100)
+
+    for _ in range(100):
+        stop()
+
+    for _ in range(100):
+        assert_(stop())

--- a/alns/stopping_criteria/tests/test_max_runtime.py
+++ b/alns/stopping_criteria/tests/test_max_runtime.py
@@ -46,20 +46,6 @@ def test_max_runtime(max_runtime):
     assert_(stop.max_runtime, max_runtime)
 
 
-@pytest.mark.parametrize("target_runtime", [0.01, 0.05, 0.1])
-def test_elapsed_runtime(target_runtime):
-    """
-    Test if the elapsed time parameter is correctly set.
-    """
-    stop = MaxRuntime(100)
-
-    stop(RandomState(), Zero(), Zero())
-    sleep(target_runtime)
-    stop(RandomState(), Zero(), Zero())
-
-    assert_almost_equal(stop.elapsed_runtime, target_runtime, decimal=3)
-
-
 @pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])
 def test_before_max_runtime(max_runtime):
     stop = MaxRuntime(max_runtime)

--- a/alns/stopping_criteria/tests/test_max_runtime.py
+++ b/alns/stopping_criteria/tests/test_max_runtime.py
@@ -1,0 +1,76 @@
+import time
+import pytest
+
+from numpy.testing import assert_, assert_almost_equal, assert_raises
+from alns.stopping_criteria import MaxRuntime
+
+
+def sleep(duration, get_now=time.perf_counter):
+    """
+    Custom sleep function. Built-in time.sleep function is not precise
+    and has different performances depending on the OS, see
+    https://stackoverflow.com/questions/1133857/how-accurate-is-pythons-time-sleep
+    """
+    now = get_now()
+    end = now + duration
+    while now < end:
+        now = get_now()
+
+
+@pytest.mark.parametrize("max_runtime", [-0.001, -1, -10.1])
+def test_raise_negative_parameters(max_runtime: float):
+    """
+    Maximum runtime may not be negative.
+    """
+    with assert_raises(ValueError):
+        MaxRuntime(max_runtime)
+
+
+@pytest.mark.parametrize("max_runtime", [0.001, 1, 10.1])
+def test_valid_parameters(max_runtime: float):
+    """
+    Does not raise for non-negative parameters.
+    """
+    MaxRuntime(max_runtime)
+
+
+@pytest.mark.parametrize("max_runtime", [0.01, 0.1, 1])
+def test_max_runtime(max_runtime):
+    """
+    Test if the max time parameter is correctly set.
+    """
+    stop = MaxRuntime(max_runtime)
+    assert_(stop.max_runtime, max_runtime)
+
+
+@pytest.mark.parametrize("target_runtime", [0.1, 0.5, 1, 2])
+def test_elapsed_runtime(target_runtime):
+    """
+    Test if the elapsed time parameter is correctly set.
+    """
+    stop = MaxRuntime(100)
+
+    stop()
+    sleep(target_runtime)
+    stop()
+
+    assert_almost_equal(stop.elapsed_runtime, target_runtime, decimal=3)
+
+
+@pytest.mark.parametrize("max_runtime", [0.01, 0.1, 100])
+def test_before_max_runtime(max_runtime):
+    stop = MaxRuntime(max_runtime)
+
+    for _ in range(100):
+        assert_(not stop())
+
+
+@pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])
+def test_after_max_runtime(max_runtime):
+    stop = MaxRuntime(max_runtime)
+
+    stop()  # Trigger the first time measurement
+    sleep(max_runtime)
+
+    for _ in range(100):
+        assert_(stop())

--- a/alns/stopping_criteria/tests/test_max_runtime.py
+++ b/alns/stopping_criteria/tests/test_max_runtime.py
@@ -1,6 +1,7 @@
 import time
 import pytest
 
+from numpy.random import RandomState
 from numpy.testing import assert_, assert_almost_equal, assert_raises
 
 from alns.stopping_criteria import MaxRuntime
@@ -45,34 +46,34 @@ def test_max_runtime(max_runtime):
     assert_(stop.max_runtime, max_runtime)
 
 
-@pytest.mark.parametrize("target_runtime", [0.1, 0.5, 1, 2])
+@pytest.mark.parametrize("target_runtime", [0.01, 0.05, 0.1])
 def test_elapsed_runtime(target_runtime):
     """
     Test if the elapsed time parameter is correctly set.
     """
     stop = MaxRuntime(100)
 
-    stop(Zero(), Zero())
+    stop(RandomState(), Zero(), Zero())
     sleep(target_runtime)
-    stop(Zero(), Zero())
+    stop(RandomState(), Zero(), Zero())
 
     assert_almost_equal(stop.elapsed_runtime, target_runtime, decimal=3)
 
 
-@pytest.mark.parametrize("max_runtime", [0.01, 0.1, 100])
+@pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])
 def test_before_max_runtime(max_runtime):
     stop = MaxRuntime(max_runtime)
-
+    rnd = RandomState()
     for _ in range(100):
-        assert_(not stop(Zero(), Zero()))
+        assert_(not stop(rnd, Zero(), Zero()))
 
 
 @pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])
 def test_after_max_runtime(max_runtime):
     stop = MaxRuntime(max_runtime)
-
-    stop(Zero(), Zero())  # Trigger the first time measurement
+    rnd = RandomState()
+    stop(rnd, Zero(), Zero())  # Trigger the first time measurement
     sleep(max_runtime)
 
     for _ in range(100):
-        assert_(stop(Zero(), Zero()))
+        assert_(stop(rnd, Zero(), Zero()))

--- a/alns/stopping_criteria/tests/test_max_runtime.py
+++ b/alns/stopping_criteria/tests/test_max_runtime.py
@@ -2,7 +2,9 @@ import time
 import pytest
 
 from numpy.testing import assert_, assert_almost_equal, assert_raises
+
 from alns.stopping_criteria import MaxRuntime
+from alns.tests.states import Zero
 
 
 def sleep(duration, get_now=time.perf_counter):
@@ -50,9 +52,9 @@ def test_elapsed_runtime(target_runtime):
     """
     stop = MaxRuntime(100)
 
-    stop()
+    stop(Zero(), Zero())
     sleep(target_runtime)
-    stop()
+    stop(Zero(), Zero())
 
     assert_almost_equal(stop.elapsed_runtime, target_runtime, decimal=3)
 
@@ -62,15 +64,15 @@ def test_before_max_runtime(max_runtime):
     stop = MaxRuntime(max_runtime)
 
     for _ in range(100):
-        assert_(not stop())
+        assert_(not stop(Zero(), Zero()))
 
 
 @pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])
 def test_after_max_runtime(max_runtime):
     stop = MaxRuntime(max_runtime)
 
-    stop()  # Trigger the first time measurement
+    stop(Zero(), Zero())  # Trigger the first time measurement
     sleep(max_runtime)
 
     for _ in range(100):
-        assert_(stop())
+        assert_(stop(Zero(), Zero()))

--- a/alns/tests/test_alns.py
+++ b/alns/tests/test_alns.py
@@ -292,7 +292,7 @@ def test_nonnegative_max_iterations(max_iterations):
     assert_equal(len(result.statistics.runtimes), max_iterations)
 
 
-@mark.parametrize("max_runtime", [0.1, 0.5, 1])
+@mark.parametrize("max_runtime", [0.01, 0.05, 0.1])
 def test_nonnegative_max_runtime(max_runtime):
     """
     Test that the result runtime statistics correspond to the stopping criterion.

--- a/alns/tests/test_alns.py
+++ b/alns/tests/test_alns.py
@@ -5,6 +5,7 @@ from pytest import mark
 
 from alns import ALNS, State
 from alns.criteria import HillClimbing, SimulatedAnnealing
+from alns.stopping_criteria import MaxIterations, MaxRuntime
 from alns.weight_schemes import SimpleWeights
 from .states import One, Zero
 
@@ -57,7 +58,7 @@ def test_on_best_is_called():
     alns.on_best(lambda *args: ValueState(10))
 
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
-    result = alns.iterate(One(), weights, HillClimbing(), 1)
+    result = alns.iterate(One(), weights, HillClimbing(), MaxIterations(1))
     assert_equal(result.best_state.objective(), 10)
 
 
@@ -140,7 +141,7 @@ def test_raises_missing_destroy_operator():
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.95)
 
     with assert_raises(ValueError):
-        alns.iterate(One(), weights, HillClimbing())
+        alns.iterate(One(), weights, HillClimbing(), MaxIterations(1))
 
 
 def test_raises_missing_repair_operator():
@@ -154,12 +155,13 @@ def test_raises_missing_repair_operator():
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.95)
 
     with assert_raises(ValueError):
-        alns.iterate(One(), weights, HillClimbing())
+        alns.iterate(One(), weights, HillClimbing(), MaxIterations(1))
 
 
-def test_raises_negative_iterations():
+def test_zero_max_iterations():
     """
-    The number of iterations should be non-negative, as zero is allowed.
+    Test that the algorithm return the initial solution when the
+    stopping criterion is zero max iterations.
     """
     alns = get_alns_instance([lambda state, rnd: None],
                              [lambda state, rnd: None])
@@ -167,12 +169,23 @@ def test_raises_negative_iterations():
     initial_solution = One()
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
 
-    # A negative iteration count is not understood, for obvious reasons.
-    with assert_raises(ValueError):
-        alns.iterate(initial_solution, weights, HillClimbing(), -1)
+    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxIterations(0))
 
-    # But zero should just return the initial solution.
-    result = alns.iterate(initial_solution, weights, HillClimbing(), 0)
+    assert_(result.best_state is initial_solution)
+
+
+def test_zero_max_runtime():
+    """
+    Test that the algorithm return the initial solution when the
+    stopping criterion is zero max runtime.
+    """
+    alns = get_alns_instance([lambda state, rnd: None],
+                             [lambda state, rnd: None])
+
+    initial_solution = One()
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+
+    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxRuntime(0))
 
     assert_(result.best_state is initial_solution)
 
@@ -189,7 +202,7 @@ def test_iterate_kwargs_are_correctly_passed_to_operators():
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
     orig_item = object()
 
-    alns.iterate(init_sol, weights, HillClimbing(), 10, item=orig_item)
+    alns.iterate(init_sol, weights, HillClimbing(), MaxIterations(10), item=orig_item)
 
 
 def test_bugfix_pass_kwargs_to_on_best():
@@ -208,7 +221,7 @@ def test_bugfix_pass_kwargs_to_on_best():
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
     orig_item = object()
 
-    alns.iterate(init_sol, weights, HillClimbing(), 10, item=orig_item)
+    alns.iterate(init_sol, weights, HillClimbing(), MaxIterations(10), item=orig_item)
 
 
 # EXAMPLES ---------------------------------------------------------------------
@@ -223,7 +236,7 @@ def test_trivial_example():
                              [lambda state, rnd: Zero()])
 
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
-    result = alns.iterate(One(), weights, HillClimbing(), 100)
+    result = alns.iterate(One(), weights, HillClimbing(), MaxIterations(100))
 
     assert_equal(result.best_state.objective(), 0)
 
@@ -242,7 +255,41 @@ def test_fixed_seed_outcomes(seed: int, desired: float):
     weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
     sa = SimulatedAnnealing(1, .25, 1 / 100)
 
-    result = alns.iterate(One(), weights, sa, 100)
+    result = alns.iterate(One(), weights, sa, MaxIterations(100))
     assert_almost_equal(result.best_state.objective(), desired, decimal=5)
+
+
+@mark.parametrize("max_iterations", [1, 10, 100])
+def test_nonnegative_max_iterations(max_iterations):
+    """
+    Test that the result statistics have size equal to max iterations (+1).
+    """
+    alns = get_alns_instance([lambda state, rnd: Zero()],
+                             [lambda state, rnd: Zero()])
+
+    initial_solution = One()
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+
+    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxIterations(max_iterations))
+
+    assert_equal(len(result.statistics.objectives), max_iterations + 1)
+    assert_equal(len(result.statistics.runtimes), max_iterations)
+
+
+@mark.parametrize("max_runtime", [0.1, 0.5, 1])
+def test_nonnegative_max_runtime(max_runtime):
+    """
+    Test that the result runtime statistics correspond to the stopping criterion.
+    """
+    alns = get_alns_instance([lambda state, rnd: Zero()],
+                             [lambda state, rnd: Zero()])
+
+    initial_solution = One()
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+
+    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxRuntime(max_runtime))
+
+    assert_almost_equal(sum(result.statistics.runtimes), max_runtime, decimal=3)
+
 
 # TODO test more complicated examples?

--- a/alns/tests/test_alns.py
+++ b/alns/tests/test_alns.py
@@ -163,13 +163,16 @@ def test_zero_max_iterations():
     Test that the algorithm return the initial solution when the
     stopping criterion is zero max iterations.
     """
-    alns = get_alns_instance([lambda state, rnd: None],
-                             [lambda state, rnd: None])
+    alns = get_alns_instance(
+        [lambda state, rnd: None], [lambda state, rnd: None]
+    )
 
     initial_solution = One()
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
 
-    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxIterations(0))
+    result = alns.iterate(
+        initial_solution, weights, HillClimbing(), MaxIterations(0)
+    )
 
     assert_(result.best_state is initial_solution)
 
@@ -179,19 +182,21 @@ def test_zero_max_runtime():
     Test that the algorithm return the initial solution when the
     stopping criterion is zero max runtime.
     """
-    alns = get_alns_instance([lambda state, rnd: None],
-                             [lambda state, rnd: None])
+    alns = get_alns_instance(
+        [lambda state, rnd: None], [lambda state, rnd: None]
+    )
 
     initial_solution = One()
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
 
-    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxRuntime(0))
+    result = alns.iterate(
+        initial_solution, weights, HillClimbing(), MaxRuntime(0)
+    )
 
     assert_(result.best_state is initial_solution)
 
 
 def test_iterate_kwargs_are_correctly_passed_to_operators():
-
     def test_operator(state, rnd, item):
         assert_(item is orig_item)
         return state
@@ -210,6 +215,7 @@ def test_bugfix_pass_kwargs_to_on_best():
     Exercises a bug where the on_best callback did not receive the kwargs passed
     to iterate().
     """
+
     def test_operator(state, rnd, item):
         assert_(item is orig_item)
         return Zero()  # better, so on_best is triggered
@@ -218,10 +224,12 @@ def test_bugfix_pass_kwargs_to_on_best():
     alns.on_best(lambda state, rnd, item: state)
 
     init_sol = One()
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
     orig_item = object()
 
-    alns.iterate(init_sol, weights, HillClimbing(), MaxIterations(10), item=orig_item)
+    alns.iterate(
+        init_sol, weights, HillClimbing(), MaxIterations(10), item=orig_item
+    )
 
 
 # EXAMPLES ---------------------------------------------------------------------
@@ -232,10 +240,11 @@ def test_trivial_example():
     This tests the ALNS algorithm on a trivial example, where the initial
     solution is one, and any other operator returns zero.
     """
-    alns = get_alns_instance([lambda state, rnd: Zero()],
-                             [lambda state, rnd: Zero()])
+    alns = get_alns_instance(
+        [lambda state, rnd: Zero()], [lambda state, rnd: Zero()]
+    )
 
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
     result = alns.iterate(One(), weights, HillClimbing(), MaxIterations(100))
 
     assert_equal(result.best_state.objective(), 0)
@@ -250,10 +259,11 @@ def test_fixed_seed_outcomes(seed: int, desired: float):
     alns = get_alns_instance(
         [lambda state, rnd: ValueState(rnd.random_sample())],
         [lambda state, rnd: None],
-        seed)
+        seed,
+    )
 
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
-    sa = SimulatedAnnealing(1, .25, 1 / 100)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
+    sa = SimulatedAnnealing(1, 0.25, 1 / 100)
 
     result = alns.iterate(One(), weights, sa, MaxIterations(100))
     assert_almost_equal(result.best_state.objective(), desired, decimal=5)
@@ -264,13 +274,19 @@ def test_nonnegative_max_iterations(max_iterations):
     """
     Test that the result statistics have size equal to max iterations (+1).
     """
-    alns = get_alns_instance([lambda state, rnd: Zero()],
-                             [lambda state, rnd: Zero()])
+    alns = get_alns_instance(
+        [lambda state, rnd: Zero()], [lambda state, rnd: Zero()]
+    )
 
     initial_solution = One()
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
 
-    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxIterations(max_iterations))
+    result = alns.iterate(
+        initial_solution,
+        weights,
+        HillClimbing(),
+        MaxIterations(max_iterations),
+    )
 
     assert_equal(len(result.statistics.objectives), max_iterations + 1)
     assert_equal(len(result.statistics.runtimes), max_iterations)
@@ -281,15 +297,20 @@ def test_nonnegative_max_runtime(max_runtime):
     """
     Test that the result runtime statistics correspond to the stopping criterion.
     """
-    alns = get_alns_instance([lambda state, rnd: Zero()],
-                             [lambda state, rnd: Zero()])
+    alns = get_alns_instance(
+        [lambda state, rnd: Zero()], [lambda state, rnd: Zero()]
+    )
 
     initial_solution = One()
-    weights = SimpleWeights([1, 1, 1, 1], 1, 1, .5)
+    weights = SimpleWeights([1, 1, 1, 1], 1, 1, 0.5)
 
-    result = alns.iterate(initial_solution, weights, HillClimbing(), MaxRuntime(max_runtime))
+    result = alns.iterate(
+        initial_solution, weights, HillClimbing(), MaxRuntime(max_runtime)
+    )
 
-    assert_almost_equal(sum(result.statistics.runtimes), max_runtime, decimal=3)
+    assert_almost_equal(
+        sum(result.statistics.runtimes), max_runtime, decimal=3
+    )
 
 
 # TODO test more complicated examples?

--- a/alns/tests/test_statistics.py
+++ b/alns/tests/test_statistics.py
@@ -41,6 +41,31 @@ def test_collect_runtimes():
     assert_allclose(statistics.runtimes, 1)  # steps of one
 
 
+def test_start_time():
+    """
+    Tests if the reference start time parameter is correctly set.
+    """
+    statistics = Statistics()
+
+    for time in range(1):
+        statistics.collect_runtime(time)
+
+    assert_equal(statistics.start_time, 0)
+
+
+def test_total_runtime():
+    """
+    Tests if the total runtime parameter is correctly set.
+    """
+    statistics = Statistics()
+
+    for time in range(100):
+        statistics.collect_runtime(time)
+
+    assert_equal(statistics.total_runtime, 99)
+
+
+
 def test_collect_destroy_counts_example():
     """
     Tests if collecting for a destroy operator works as expected in a simple


### PR DESCRIPTION
# Related issue: #62 
I had more free time than I predicted :-).

The changes I made mainly follow the same implementation style of the acceptance criteria.

## Changes
- Implement a `StoppingCriterion` class and provide two default criteria `MaxIterations` and `MaxRuntime`
- Changed the `ALNS.iterate` interface to take `stop: StoppingCriterion` parameter as input instead of `iterations: int`

## Motivation behind the `StoppingCriterion` interface:
- In particular: `StoppingCriterion.__call__(self, best: State, current: State)`
- I searched through the Handbook of Metaheuristics (2019) for termination criteria possibilities. Section 2.3.7. on Tabu Search - Termination criteria gives the following examples:

  > One may have noticed that we have not specified in our template above a termination criterion. In theory, the search could go on forever, unless the optimal value of the problem at hand is known beforehand. In practice, obviously, the search has to be stopped at some point. The most commonly used stopping criteria in TS are:
  > • after a fixed number of iterations (or a fixed amount of CPU time);
  > • after some number of iterations without an improvement in the objective function
  > value (the criterion used in most implementations);
  > • when the objective reaches a pre-specified threshold value.

- I based my implementation to take into account these points. The first point is addressed by the implementation of `MaxIterations` and `MaxRuntime`. The second and third point can be implemented based on this interface, which would not have been possible if `__call__` does not accept the best and current solution.

## Remarks
- I didn't know what to do with the linting/formatting since it wasn't specified in `pyproject.toml`. 
- I only changed the tests to make sure they all passed due to the new iterate interface, but I haven't changed the documentation/examples yet. I can do this after we've decided on the proposed changes.

