### PR TITLE
NoImprovement stopping criterion

### DIFF
--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -8,7 +8,10 @@ from alns.stop.StoppingCriterion import StoppingCriterion
 class NoImprovement(StoppingCriterion):
     """
     Criterion that stops if the best solution has not been improved
-    after a number of iterations.
+    for a number of iterations.
+
+    The first iteration is used to initialize the criterion. Hence,
+    the algorithm will iterate at least n_iterations + 1 times.
 
     Parameters
     ----------

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -1,4 +1,5 @@
 from numpy.random import RandomState
+from typing import Optional
 
 from alns.State import State
 from alns.stop.StoppingCriterion import StoppingCriterion
@@ -20,8 +21,7 @@ class NoImprovement(StoppingCriterion):
             raise ValueError("n_iterations < 0 not understood.")
 
         self._n_iterations = n_iterations
-        self._counter = None
-        self._target = None
+        self._target: Optional[float] = None
 
     @property
     def n_iterations(self) -> int:

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -8,7 +8,7 @@ from alns.stop.StoppingCriterion import StoppingCriterion
 class NoImprovement(StoppingCriterion):
     """
     Criterion that stops if the best solution has not been improved
-    for a number of iterations.
+    after a number of iterations.
 
     The first iteration is used to initialize the criterion. Hence,
     the algorithm will iterate at least n_iterations + 1 times.

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -22,6 +22,7 @@ class NoImprovement(StoppingCriterion):
 
         self._max_iterations = max_iterations
         self._target: Optional[float] = None
+        self._counter = 0
 
     @property
     def max_iterations(self) -> int:
@@ -31,7 +32,7 @@ class NoImprovement(StoppingCriterion):
         if self._target is None or best.objective() < self._target:
             self._target = best.objective()
             self._counter = 0
-            return False
+        else:
+            self._counter += 1
 
-        self._counter += 1
         return self._counter >= self.max_iterations

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -10,25 +10,22 @@ class NoImprovement(StoppingCriterion):
     Criterion that stops if the best solution has not been improved
     after a number of iterations.
 
-    The first iteration is used to initialize the criterion. Hence,
-    the algorithm will iterate at least n_iterations + 1 times.
-
     Parameters
     ----------
-    n_iterations
+    max_iterations
         The maximum number of non-improving iterations.
     """
 
-    def __init__(self, n_iterations: int):
-        if n_iterations < 0:
-            raise ValueError("n_iterations < 0 not understood.")
+    def __init__(self, max_iterations: int):
+        if max_iterations < 0:
+            raise ValueError("max_iterations < 0 not understood.")
 
-        self._n_iterations = n_iterations
+        self._max_iterations = max_iterations
         self._target: Optional[float] = None
 
     @property
-    def n_iterations(self) -> int:
-        return self._n_iterations
+    def max_iterations(self) -> int:
+        return self._max_iterations
 
     def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
         if self._target is None or best.objective() < self._target:
@@ -37,4 +34,4 @@ class NoImprovement(StoppingCriterion):
             return False
 
         self._counter += 1
-        return self._counter > self.n_iterations
+        return self._counter >= self.max_iterations

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -1,0 +1,37 @@
+from numpy.random import RandomState
+
+from alns.State import State
+from alns.stop.StoppingCriterion import StoppingCriterion
+
+
+class NoImprovement(StoppingCriterion):
+    """
+    Criterion that stops if the best solution has not been improved
+    after a number of iterations.
+
+    Parameters
+    ----------
+    n_iterations
+        The maximum number of non-improving iterations.
+    """
+
+    def __init__(self, n_iterations: int):
+        if n_iterations < 0:
+            raise ValueError("n_iterations < 0 not understood.")
+
+        self._n_iterations = n_iterations
+        self._counter = None
+        self._target = None
+
+    @property
+    def n_iterations(self) -> int:
+        return self._n_iterations
+
+    def __call__(self, rnd: RandomState, best: State, current: State) -> bool:
+        if self._target is None or best.objective() < self._target:
+            self._target = best.objective()
+            self._counter = 0
+            return False
+
+        self._counter += 1
+        return self._counter > self.n_iterations

--- a/alns/stop/__init__.py
+++ b/alns/stop/__init__.py
@@ -1,3 +1,4 @@
 from .MaxIterations import MaxIterations
 from .MaxRuntime import MaxRuntime
+from .NoImprovement import NoImprovement
 from .StoppingCriterion import StoppingCriterion

--- a/alns/stop/tests/test_max_iterations.py
+++ b/alns/stop/tests/test_max_iterations.py
@@ -1,6 +1,6 @@
 import pytest
 from numpy.random import RandomState
-from numpy.testing import assert_, assert_raises
+from numpy.testing import assert_, assert_equal, assert_raises
 
 from alns.stop import MaxIterations
 from alns.tests.states import Zero
@@ -29,7 +29,7 @@ def test_max_iterations(max_iterations):
     Test if the max iterations parameter is correctly set.
     """
     stop = MaxIterations(max_iterations)
-    assert stop.max_iterations == max_iterations
+    assert_equal(stop.max_iterations, max_iterations)
 
 
 def test_before_max_iterations():

--- a/alns/stop/tests/test_max_runtime.py
+++ b/alns/stop/tests/test_max_runtime.py
@@ -2,7 +2,7 @@ import time
 
 import pytest
 from numpy.random import RandomState
-from numpy.testing import assert_, assert_raises
+from numpy.testing import assert_, assert_equal, assert_raises
 
 from alns.stop import MaxRuntime
 from alns.tests.states import Zero
@@ -43,7 +43,7 @@ def test_max_runtime(max_runtime):
     Test if the max time parameter is correctly set.
     """
     stop = MaxRuntime(max_runtime)
-    assert_(stop.max_runtime, max_runtime)
+    assert_equal(stop.max_runtime, max_runtime)
 
 
 @pytest.mark.parametrize("max_runtime", [0.01, 0.05, 0.10])

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -16,10 +16,10 @@ def test_raise_negative_parameters(n_iterations: int):
         NoImprovement(n_iterations)
 
 
-@pytest.mark.parametrize("n_iterations", [10, 100, 1000])
+@pytest.mark.parametrize("n_iterations", [0, 10, 100, 1000])
 def test_does_not_raise(n_iterations: int):
     """
-    Valid parameters should not raise.
+    Non-negative integers should not raise.
     """
     NoImprovement(n_iterations)
 
@@ -58,6 +58,8 @@ def test_after_n_iterations():
         stop(rnd, Zero(), Zero())
 
     for _ in range(100):
+        # The 102-th iteration and beyond should be stopped, because there was
+        # 1 iteration to initialize and 100 subsequent non-improving iterations.
         assert_(stop(rnd, Zero(), Zero()))
 
 

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -7,29 +7,29 @@ from alns.tests.states import One, Zero, Two
 from alns.stop import NoImprovement
 
 
-@pytest.mark.parametrize("n_iterations", [-10, -100, -1000])
-def test_raise_negative_parameters(n_iterations: int):
+@pytest.mark.parametrize("max_iterations", [-10, -100, -1000])
+def test_raise_negative_parameters(max_iterations: int):
     """
-    n_iterations cannot be negative.
+    max_iterations cannot be negative.
     """
     with assert_raises(ValueError):
-        NoImprovement(n_iterations)
+        NoImprovement(max_iterations)
 
 
-@pytest.mark.parametrize("n_iterations", [0, 10, 100, 1000])
-def test_does_not_raise(n_iterations: int):
+@pytest.mark.parametrize("max_iterations", [0, 10, 100, 1000])
+def test_does_not_raise(max_iterations: int):
     """
     Non-negative integers should not raise.
     """
-    NoImprovement(n_iterations)
+    NoImprovement(max_iterations)
 
 
-def test_n_iterations():
+def test_max_iterations():
     """
-    Test if the n_iterations parameter is correctly set.
+    Test if the max_iterations parameter is correctly set.
     """
     stop = NoImprovement(3)
-    assert stop.n_iterations == 3
+    assert_equal(stop.max_iterations, 3)
 
 
 def test_first_iteration():
@@ -39,40 +39,42 @@ def test_first_iteration():
     stop = NoImprovement(100)
     rnd = RandomState()
 
-    assert not stop(rnd, Zero(), Zero())
+    assert_(not stop(rnd, Zero(), One()))
 
 
-def test_before_n_iterations():
+def test_stop_after_max_iterations():
     stop = NoImprovement(100)
     rnd = RandomState()
 
     for _ in range(100):
         assert_(not stop(rnd, Zero(), Zero()))
 
-
-def test_after_n_iterations():
-    stop = NoImprovement(100)
-    rnd = RandomState()
-
-    for _ in range(100 + 1):
-        stop(rnd, Zero(), Zero())
-
     for _ in range(100):
-        # The 102-th iteration and beyond should be stopped, because there was
-        # 1 iteration to initialize and 100 subsequent non-improving iterations.
         assert_(stop(rnd, Zero(), Zero()))
 
 
-@pytest.mark.parametrize("n_iterations", [10, 100, 1000])
-def test_reset_counter(n_iterations):
+def test_counter_value_at_stop():
     """
-    Test if the counter is reset when an improving solution is encountered.
+    Test if the counter value is equal to the passed-in max iterations
+    at the first stopping occurence.
     """
-    stop = NoImprovement(n_iterations)
+    stop = NoImprovement(100)
+
+    while not stop(RandomState(), Zero(), Zero()):
+        pass
+
+    assert_equal(stop._counter, 100)
+
+
+def test_reset_counter():
+    """
+    Test if the counter is reset when a new best solution is encountered.
+    """
+    stop = NoImprovement(100)
     rnd = RandomState()
 
-    for _ in range(n_iterations):
-        assert_(not stop(rnd, Two(), Zero()))
+    for _ in range(5):
+        assert_(not stop(rnd, One(), One()))
 
-    assert not stop(rnd, One(), Zero())
-    assert stop._counter == 0
+    assert_(not stop(rnd, Zero(), One()))
+    assert_equal(stop._counter, 0)

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -32,6 +32,19 @@ def test_max_iterations():
     assert_equal(stop.max_iterations, 3)
 
 
+def test_zero_max_iterations():
+    """
+    Test if setting max_iterations to zero stops when a non-improving
+    best solution has been found.
+    """
+    stop = NoImprovement(0)
+    rnd = RandomState()
+
+    assert_(not stop(rnd, One(), Zero()))
+    assert_(not stop(rnd, Zero(), Zero()))
+    assert_(stop(rnd, Zero(), Zero()))
+
+
 def test_first_iteration():
     """
     Test if the first iteration does not stop.

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -77,17 +77,3 @@ def test_counter_value_at_stop():
         pass
 
     assert_equal(stop._counter, 100)
-
-
-def test_reset_counter():
-    """
-    Test if the counter is reset when a new best solution is encountered.
-    """
-    stop = NoImprovement(100)
-    rnd = RandomState()
-
-    for _ in range(5):
-        assert_(not stop(rnd, One(), One()))
-
-    assert_(not stop(rnd, Zero(), One()))
-    assert_equal(stop._counter, 0)

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -17,19 +17,12 @@ def test_raise_negative_parameters(max_iterations: int):
 
 
 @pytest.mark.parametrize("max_iterations", [0, 10, 100, 1000])
-def test_does_not_raise(max_iterations: int):
-    """
-    Non-negative integers should not raise.
-    """
-    NoImprovement(max_iterations)
-
-
-def test_max_iterations():
+def test_max_iterations(max_iterations):
     """
     Test if the max_iterations parameter is correctly set.
     """
-    stop = NoImprovement(3)
-    assert_equal(stop.max_iterations, 3)
+    stop = NoImprovement(max_iterations)
+    assert_equal(stop.max_iterations, max_iterations)
 
 
 def test_zero_max_iterations():
@@ -56,37 +49,39 @@ def test_one_max_iterations():
     assert_(stop(rnd, Zero(), Zero()))
 
 
-def test_n_max_iterations_non_improving():
+@pytest.mark.parametrize("n", [10, 100, 1000])
+def test_n_max_iterations_non_improving(n):
     """
-    Test if setting max_iterations to N correctly stops with non-improving
-    solutions. The first N iterations should not stop. Beyond that, the
+    Test if setting max_iterations to n correctly stops with non-improving
+    solutions. The first n iterations should not stop. Beyond that, the
     the criterion should stop.
     """
-    stop = NoImprovement(100)
+    stop = NoImprovement(n)
     rnd = RandomState()
 
-    for _ in range(100):
+    for _ in range(n):
         assert_(not stop(rnd, Zero(), Zero()))
 
-    for _ in range(100):
+    for _ in range(n):
         assert_(stop(rnd, Zero(), Zero()))
 
 
-def test_n_max_iterations_with_single_improvement():
+@pytest.mark.parametrize("n, k", [(10, 2), (100, 20), (1000, 200)])
+def test_n_max_iterations_with_single_improvement(n, k):
     """
-    Test if setting max_iterations to N correctly stops with a sequence
-    of solutions, where the third solution is improving and the other solutions
-    are non-improving. The first N+2 iterations should not stop. Beyond that,
+    Test if setting max_iterations to n correctly stops with a sequence
+    of solutions, where the k-th solution is improving and the other solutions
+    are non-improving. The first n+k-1 iterations should not stop. Beyond that,
     the criterion should stop.
     """
-    stop = NoImprovement(100)
+    stop = NoImprovement(n)
     rnd = RandomState()
 
-    for _ in range(2):
+    for _ in range(k):
         assert_(not stop(rnd, One(), Zero()))
 
-    for _ in range(100):
+    for _ in range(n):
         assert_(not stop(rnd, Zero(), Zero()))
 
-    for _ in range(100):
+    for _ in range(n):
         assert_(stop(rnd, Zero(), Zero()))

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -1,0 +1,76 @@
+import pytest
+from numpy.random import RandomState
+from numpy.testing import assert_, assert_equal, assert_raises
+
+from alns.tests.states import One, Zero, Two
+
+from alns.stop import NoImprovement
+
+
+@pytest.mark.parametrize("n_iterations", [-10, -100, -1000])
+def test_raise_negative_parameters(n_iterations: int):
+    """
+    n_iterations cannot be negative.
+    """
+    with assert_raises(ValueError):
+        NoImprovement(n_iterations)
+
+
+@pytest.mark.parametrize("n_iterations", [10, 100, 1000])
+def test_does_not_raise(n_iterations: int):
+    """
+    Valid parameters should not raise.
+    """
+    NoImprovement(n_iterations)
+
+
+def test_n_iterations():
+    """
+    Test if the n_iterations parameter is correctly set.
+    """
+    stop = NoImprovement(3)
+    assert stop.n_iterations == 3
+
+
+def test_first_iteration():
+    """
+    Test if the first iteration does not stop.
+    """
+    stop = NoImprovement(100)
+    rnd = RandomState()
+
+    assert not stop(rnd, Zero(), Zero())
+
+
+def test_before_n_iterations():
+    stop = NoImprovement(100)
+    rnd = RandomState()
+
+    for _ in range(100):
+        assert_(not stop(rnd, Zero(), Zero()))
+
+
+def test_after_n_iterations():
+    stop = NoImprovement(100)
+    rnd = RandomState()
+
+    for _ in range(100 + 1):
+        stop(rnd, Zero(), Zero())
+
+    for _ in range(100):
+        assert_(stop(rnd, Zero(), Zero()))
+
+
+@pytest.mark.parametrize("n_iterations", [10, 100, 1000])
+def test_reset_counter(n_iterations):
+    """
+    Test if the counter is reset when an improving solution is encountered.
+    """
+    stop = NoImprovement(n_iterations)
+    rnd = RandomState()
+
+    for _ in range(n_iterations):
+        assert_(not stop(rnd, Two(), Zero()))
+
+    assert not stop(rnd, One(), Zero())
+    assert stop._counter == 0

--- a/alns/stop/tests/test_no_improvement.py
+++ b/alns/stop/tests/test_no_improvement.py
@@ -34,10 +34,21 @@ def test_max_iterations():
 
 def test_zero_max_iterations():
     """
-    Test if setting max_iterations to zero stops when a non-improving
-    best solution has been found.
+    Test if setting max_iterations to zero always stops.
     """
     stop = NoImprovement(0)
+    rnd = RandomState()
+
+    assert_(stop(rnd, One(), Zero()))
+    assert_(stop(rnd, Zero(), Zero()))
+
+
+def test_one_max_iterations():
+    """
+    Test if setting max_iterations to one only stops when a non-improving
+    best solution has been found.
+    """
+    stop = NoImprovement(1)
     rnd = RandomState()
 
     assert_(not stop(rnd, One(), Zero()))
@@ -45,17 +56,12 @@ def test_zero_max_iterations():
     assert_(stop(rnd, Zero(), Zero()))
 
 
-def test_first_iteration():
+def test_n_max_iterations_non_improving():
     """
-    Test if the first iteration does not stop.
+    Test if setting max_iterations to N correctly stops with non-improving
+    solutions. The first N iterations should not stop. Beyond that, the
+    the criterion should stop.
     """
-    stop = NoImprovement(100)
-    rnd = RandomState()
-
-    assert_(not stop(rnd, Zero(), One()))
-
-
-def test_stop_after_max_iterations():
     stop = NoImprovement(100)
     rnd = RandomState()
 
@@ -66,14 +72,21 @@ def test_stop_after_max_iterations():
         assert_(stop(rnd, Zero(), Zero()))
 
 
-def test_counter_value_at_stop():
+def test_n_max_iterations_with_single_improvement():
     """
-    Test if the counter value is equal to the passed-in max iterations
-    at the first stopping occurence.
+    Test if setting max_iterations to N correctly stops with a sequence
+    of solutions, where the third solution is improving and the other solutions
+    are non-improving. The first N+2 iterations should not stop. Beyond that,
+    the criterion should stop.
     """
     stop = NoImprovement(100)
+    rnd = RandomState()
 
-    while not stop(RandomState(), Zero(), Zero()):
-        pass
+    for _ in range(2):
+        assert_(not stop(rnd, One(), Zero()))
 
-    assert_equal(stop._counter, 100)
+    for _ in range(100):
+        assert_(not stop(rnd, Zero(), Zero()))
+
+    for _ in range(100):
+        assert_(stop(rnd, Zero(), Zero()))


### PR DESCRIPTION
# Changes
- `NoImprovement` stopping criterion. This criterion allows ALNS to iterate until the best solution has not improved for a user-specified number of iterations `n_iterations`.
