### PR TITLE
Add pre-commit + isort

### DIFF
--- a/.github/workflows/alns.yml
+++ b/.github/workflows/alns.yml
@@ -32,6 +32,7 @@ jobs:
         run: poetry run pytest
       - name: Run pre-commit
         run: poetry run pre-commit run --all-files
+      - uses: codecov/codecov-action@v3
   deploy:
     needs: build
     if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/alns.yml
+++ b/.github/workflows/alns.yml
@@ -27,15 +27,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install
+          poetry run pre-commit install
       - name: Run pytest
         run: poetry run pytest
-      - name: Run black
-        uses: psf/black@stable
-      - name: Run flake8
-        uses: py-actions/flake8@v2
-      - name: Run mypy
-        run: poetry run mypy alns
-      - uses: codecov/codecov-action@v3
+      - name: Run pre-commit
+        run: poetry run pre-commit run --all-files
   deploy:
     needs: build
     if: github.event_name == 'release' && github.event.action == 'created'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,3 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
-        args: [--ignore_missing_imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+fail_fast: true
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.2.0
@@ -19,3 +21,4 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
+        args: [--ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-        args: ["--profile", "black", --line-length=79]
+        args: [--profile=black, --line-length=79]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,6 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
-        args: [--line-length=79]
 
 -   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
@@ -21,11 +20,8 @@ repos:
     rev: 5.10.1
     hooks:
       - id: isort
-        name: isort (python)
-        args: [--profile=black, --line-length=79]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
     -   id: mypy
-        args: [--ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
     rev: 4.0.1
     hooks:
     -   id: flake8
+        args: [--per-file-ignores=__init__.py:F401, --extend-ignore="E203"]
 
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
     hooks:
     -   id: flake8
 
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black", --line-length=79]
+
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
+        args: [--line-length=79]
 
 -   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
@@ -19,9 +20,11 @@ repos:
 -   repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
-      - id: isort
+    -   id: isort
+        args: [--case-sensitive, --profile=black, --line-length=79]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.982
     hooks:
     -   id: mypy
+        args: [--ignore-missing-imports]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: debug-statements
+
+-   repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+    -   id: black
+        args: [--line-length=79]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+    -   id: flake8
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.982
+    hooks:
+    -   id: mypy
+        args: [--ignore_missing_imports]

--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -4,12 +4,12 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy.random as rnd
 
+from alns.accept import AcceptanceCriterion
 from alns.Outcome import Outcome
 from alns.Result import Result
+from alns.select import OperatorSelectionScheme
 from alns.State import State
 from alns.Statistics import Statistics
-from alns.accept import AcceptanceCriterion
-from alns.select import OperatorSelectionScheme
 from alns.stop import StoppingCriterion
 
 # TODO these should become Protocol to allow for kwargs. See also this issue:

--- a/alns/ALNS.py
+++ b/alns/ALNS.py
@@ -4,12 +4,12 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy.random as rnd
 
-from alns.accept import AcceptanceCriterion
 from alns.Outcome import Outcome
 from alns.Result import Result
-from alns.select import OperatorSelectionScheme
 from alns.State import State
 from alns.Statistics import Statistics
+from alns.accept import AcceptanceCriterion
+from alns.select import OperatorSelectionScheme
 from alns.stop import StoppingCriterion
 
 # TODO these should become Protocol to allow for kwargs. See also this issue:

--- a/alns/accept/tests/test_record_to_record_travel.py
+++ b/alns/accept/tests/test_record_to_record_travel.py
@@ -1,10 +1,5 @@
 import numpy.random as rnd
-from numpy.testing import (
-    assert_,
-    assert_allclose,
-    assert_equal,
-    assert_raises,
-)
+from numpy.testing import assert_, assert_allclose, assert_equal, assert_raises
 from pytest import mark
 
 from alns.accept import RecordToRecordTravel

--- a/alns/select/RouletteWheel.py
+++ b/alns/select/RouletteWheel.py
@@ -3,8 +3,8 @@ from typing import List, Optional, Tuple
 import numpy as np
 from numpy.random import RandomState
 
-from alns.select.OperatorSelectionScheme import OperatorSelectionScheme
 from alns.State import State
+from alns.select.OperatorSelectionScheme import OperatorSelectionScheme
 
 
 class RouletteWheel(OperatorSelectionScheme):

--- a/alns/select/SegmentedRouletteWheel.py
+++ b/alns/select/SegmentedRouletteWheel.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 
 import numpy as np
 
-from alns.select.RouletteWheel import RouletteWheel
 from alns.State import State
+from alns.select.RouletteWheel import RouletteWheel
 
 logger = logging.getLogger(__name__)
 

--- a/alns/stop/MaxRuntime.py
+++ b/alns/stop/MaxRuntime.py
@@ -1,6 +1,6 @@
 import time
-
 from typing import Optional
+
 from numpy.random import RandomState
 
 from alns.State import State

--- a/alns/stop/NoImprovement.py
+++ b/alns/stop/NoImprovement.py
@@ -1,5 +1,6 @@
-from numpy.random import RandomState
 from typing import Optional
+
+from numpy.random import RandomState
 
 from alns.State import State
 from alns.stop.StoppingCriterion import StoppingCriterion

--- a/alns/tests/test_alns.py
+++ b/alns/tests/test_alns.py
@@ -11,8 +11,8 @@ from alns import ALNS
 from alns.accept import HillClimbing, SimulatedAnnealing
 from alns.select import RouletteWheel
 from alns.stop import MaxIterations, MaxRuntime
-from .states import One, VarObj, Zero
 
+from .states import One, VarObj, Zero
 
 # HELPERS ---------------------------------------------------------------------
 

--- a/alns/tests/test_result.py
+++ b/alns/tests/test_result.py
@@ -5,6 +5,7 @@ from numpy.testing import assert_
 
 from alns.Result import Result
 from alns.Statistics import Statistics
+
 from .states import Sentinel
 
 try:

--- a/alns/tests/test_statistics.py
+++ b/alns/tests/test_statistics.py
@@ -1,4 +1,4 @@
-from numpy.testing import assert_equal, assert_almost_equal, assert_allclose
+from numpy.testing import assert_allclose, assert_almost_equal, assert_equal
 
 from alns.Statistics import Statistics
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ numpy = ">=1.15.2"
 matplotlib = ">=2.2.0"
 
 [tool.poetry.dev-dependencies]
+pre-commit = "^2.20.0"
 pytest = ">=6.0.0"
 pytest-cov = ">=2.6.1"
 mypy = ">=0.670"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,7 @@ matplotlib = ">=2.2.0"
 pre-commit = "^2.20.0"
 pytest = ">=6.0.0"
 pytest-cov = ">=2.6.1"
-mypy = ">=0.670"
 codecov = "*"
-black = "^22.3.0"
-flake8 = "^4.0.1"
 
 # These are solely for work on the example notebooks, and not required for
 # the package itself.
@@ -49,23 +46,12 @@ cvrplib = "^0.1.1"
 networkx = ">=2.4.0"
 tsplib95 = ">=0.7.0"
 
-
-
-[tool.mypy]
-# These are generally already settled anyway, so there's no real
-# need to worry about them here
-ignore_missing_imports = true
-
-
-
 [tool.pytest.ini_options]
 markers = [
     "matplotlib: test related to matplotlib functionality.",
 ]
 
 addopts = "--cov=. --cov-report=xml"
-
-
 
 [tool.coverage.run]
 omit = [
@@ -81,18 +67,6 @@ exclude_lines = [
     "pragma: no cover",
     "@abstract"
 ]
-
-
-
-[tool.black]
-line-length = 79
-
-[tool.isort]
-case_sensitive = true
-profile = "black"
-line_length = 79
-
-
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,11 @@ exclude_lines = [
 [tool.black]
 line-length = 79
 
+[tool.isort]
+case_sensitive = true
+profile = "black"
+line_length = 79
+
 
 
 [build-system]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[flake8]
-per-file-ignores = __init__.py:F401
-extend-ignore =
-    # See https://github.com/PyCQA/pycodestyle/issues/373
-    "E203",


### PR DESCRIPTION
Closes #90.
- Add pre-commit to poetry
- Add pre-commit configuration with current dev dependencies
- Add isort as new dependency
- Remove linters/type checkers from poetry dev dependencies