### PR TITLE
Intro to ALNS page in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ The documentation is available [here][1].
 
 ### Getting started
 
+If you are new to metaheuristics or ALNS, you might benefit from reading
+the [introduction to ALNS][11] page.
+
 The `alns` library provides the ALNS algorithm and various acceptance criteria,
 operator selection schemes, and stopping criteria. To solve your own problem,
 you should provide the following:
@@ -90,3 +93,5 @@ If you are looking for help, please follow the instructions [here][7].
 [9]: https://alns.readthedocs.io/en/latest/examples/permutation_flow_shop_problem.html
 
 [10]: https://alns.readthedocs.io/en/latest/setup/template.html
+
+[11]: https://alns.readthedocs.io/en/latest/setup/introduction_to_alns.html

--- a/docs/source/api/accept.rst
+++ b/docs/source/api/accept.rst
@@ -8,7 +8,7 @@ Acceptance criteria
 The :mod:`alns.accept` module contains the various acceptance criteria the `alns` package ships with.
 These criteria are used by the ALNS algorithm to decide whether to accept or reject a candidate solution.
 
-All acceptance criteria inherit from :class:`~alns.accept.AcceptanceCriterion.AcceptanceCriterion`, which can be subclassed to create your own.
+All acceptance criteria inherit from :class:`~alns.accept.AcceptanceCriterion.AcceptanceCriterion`.
 
 .. automodule:: alns.accept.AcceptanceCriterion
    :members:

--- a/docs/source/api/alns.rst
+++ b/docs/source/api/alns.rst
@@ -5,9 +5,7 @@
 ALNS
 ====
 
-The top-level :mod:`alns` module contains two public classes: :class:`~alns.ALNS.ALNS` and :class:`~alns.State.State`.
-The first is used to run the ALNS algorithm.
-The second can be subclassed to define a solution state: all that is needed is to define a `objective()` member function that returns the solution cost.
+The top-level :mod:`alns` module exposes the :class:`~alns.ALNS.ALNS` class, which is used to run the ALNS algorithm.
 
 Finally, the :meth:`~alns.ALNS.ALNS.iterate` method on :class:`~alns.ALNS.ALNS` instances returns a :class:`~alns.Result.Result` object.
 Its properties and methods can be used to access the final solution and runtime statistics.

--- a/docs/source/api/select.rst
+++ b/docs/source/api/select.rst
@@ -8,7 +8,7 @@ Operator selection schemes
 The :mod:`alns.select` module contains the various operator selection schemes the `alns` package ships with.
 These are used during the ALNS search to select a destroy and repair operator pair in each iteration.
 
-All operator selection schemes inherit from :class:`~alns.select.OperatorSelectionScheme.OperatorSelectionScheme`, which can be subclassed to create your own.
+All operator selection schemes inherit from :class:`~alns.select.OperatorSelectionScheme.OperatorSelectionScheme`.
 
 .. automodule:: alns.select.OperatorSelectionScheme
    :members:

--- a/docs/source/api/stop.rst
+++ b/docs/source/api/stop.rst
@@ -8,7 +8,7 @@ Stopping criteria
 The :mod:`alns.stop` module contains the various stopping criteria the `alns` package ships with.
 These can be used to stop the ALNS search whenever some criterion is met: for example, when some maximum number of iterations or run-time is exceeded.
 
-All stopping criteria inherit from :class:`~alns.stop.StoppingCriterion.StoppingCriterion`, which can be subclassed to create your own.
+All stopping criteria inherit from :class:`~alns.stop.StoppingCriterion.StoppingCriterion`.
 
 .. automodule:: alns.stop.StoppingCriterion
    :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,9 +34,9 @@ It can be installed through *pip* via
 
    setup/installation
    setup/introduction_to_alns
+   setup/template
    setup/contributing
    setup/getting_help
-   setup/template
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,11 +22,11 @@ It can be installed through *pip* via
 
    pip install alns
 
-.. note::
+.. hint::
 
-    Have a look at the :doc:` quickstart template <setup/template>` to get started on your own ALNS metaheuristic.
+    Have a look at the :doc:`quickstart template <setup/template>` to get started on your own ALNS metaheuristic.
     If you are new to metaheuristics or ALNS, you might also benefit from reading the :doc:`introduction to ALNS <setup/introduction_to_alns>`.
-    To set-up an installation from source, or to run the examples listed below yourself, please have a look at the :doc:`installation instructions <setup/installation>`.
+    To set up an installation from source, or to run the examples listed below yourself, please have a look at the :doc:`installation instructions <setup/installation>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,9 +24,9 @@ It can be installed through *pip* via
 
 .. note::
 
-    Have a look at the :doc:`setup/template` to get started on your own ALNS metaheuristic.
-    If you are new to metaheuristics or ALNS, you might also benefit from reading :doc:`setup/introduction_to_alns`.
-    To set-up an installation from source, or to run the examples listed below yourself, please have a look at the :doc:`setup/installation`.
+    Have a look at the :doc:` quickstart template <setup/template>` to get started on your own ALNS metaheuristic.
+    If you are new to metaheuristics or ALNS, you might also benefit from reading the :doc:`introduction to ALNS <setup/introduction_to_alns>`.
+    To set-up an installation from source, or to run the examples listed below yourself, please have a look at the :doc:`installation instructions <setup/installation>`.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,7 @@ It can be installed through *pip* via
 .. note::
 
     Have a look at the :doc:`setup/template` to get started on your own ALNS metaheuristic.
+    If you are new to metaheuristics or ALNS, you might also benefit from reading :doc:`setup/introduction_to_alns`.
     To set-up an installation from source, or to run the examples listed below yourself, please have a look at the :doc:`setup/installation`.
 
 .. toctree::
@@ -32,6 +33,7 @@ It can be installed through *pip* via
    :caption: Getting started
 
    setup/installation
+   setup/introduction_to_alns
    setup/contributing
    setup/getting_help
    setup/template

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -1,0 +1,4 @@
+A brief introduction to ALNS
+============================
+
+TODO

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -59,10 +59,7 @@ In pseudocode, ALNS works as follows:
         **return** :math:`s^*`
 
 The ``alns`` package provides the ALNS algorithm, stopping and acceptance criteria, and various operator selection schemes for you.
-You need to provide:
-
-* An initial solution.
-* One or more destroy and repair operators tailored to your problem.
+You need to provide an initial solution, and one or more destroy and repair operators tailored to your problem.
 
 .. hint::
 

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -5,7 +5,7 @@ Before we explain what ALNS is, we first need to describe the type of problems i
 These problems typically come from the field of `combinatorial optimisation <https://en.wikipedia.org/wiki/Combinatorial_optimization>`_, and have
 
 * A large (but finite) set of solutions (the *search space*)
-* An objective to be optimised by finding a *good* solution in the search space
+* An objective function to be optimised by finding a *good* solution in the search space
 
 A very well-known example of such a problem is the `travelling salesman problem <https://en.wikipedia.org/wiki/Travelling_salesman_problem>`_ (TSP), which asks
 
@@ -14,15 +14,14 @@ A very well-known example of such a problem is the `travelling salesman problem 
 It is easy to find *a* solution: :math:`1 \rightarrow 2 \rightarrow 3 \rightarrow \ldots \rightarrow n \rightarrow 1` is one option.
 Finding an *optimal* solution, however, can be very difficult since there are :math:`n!` possible solutions, and the search space thus grows very quickly with :math:`n`.
 
-Because of the explosive growth of the search space, combinatorial problems cannot be solved optimally by testing every solution in the search space.
-In such cases, a heuristic method can help find good (but not necessarily optimal) solutions quickly.
-ALNS is one such heuristic method.
-
 .. note::
 
-    :ref:`/examples/travelling_salesman_problem.ipynb` solves a TSP instance using ALNS.
+    :ref:`This example notebooks </examples/travelling_salesman_problem.ipynb>` solves a TSP instance using ALNS.
 
-Specifically, the adaptive large neighbourhood search metaheuristic is:
+Due to the explosive growth of the search space, most combinatorial problems cannot be solved optimally by testing every solution in the search space.
+For these problems, a heuristic method can help find good (but not necessarily optimal) solutions quickly.
+The adaptive large neighbourhood search (ALNS) algorithm is one such heuristic method.
+Specifically, ALNS is:
 
 * A large neighbourhood search (LNS) method.
   LNS methods explore large subsets of the search space in a systematic manner.
@@ -34,14 +33,19 @@ Specifically, the adaptive large neighbourhood search metaheuristic is:
 * Adaptive.
   During the search, ALNS learns about operators that are more effective than others, and uses that information to choose those effective operators more often.
 
+.. note::
+
+    For a more thorough introduction to LNS and LNS-based metaheuristics like ALNS, the handbook chapter of `Pisinger and Røpke (2019) <https://doi.org/10.1007/978-3-319-91086-4_4>`_ may be useful.
+
 ALNS begins with an initial solution and then iterates until a stopping criterion is met.
 In each iteration, a destroy and repair operator are selected, which transform the current solution into a candidate solution.
 This candidate solution is then evaluated by an acceptance criterion, and the operator selection scheme is updated based on the evaluation outcome.
+Once the stopping criterion is met, ALNS returns the best solution it has found.
 In pseudocode, ALNS works as follows:
 
     .. line-block::
 
-        **Input:** an initial solution :math:`s`
+        **Input:** initial solution :math:`s`
         **Output:** optimised solution :math:`s^*`
         :math:`s^* \gets s`
         **repeat** until stopping criteria is met:
@@ -60,9 +64,6 @@ You need to provide:
 * An initial solution.
 * One or more destroy and repair operators tailored to your problem.
 
-Typically, a good start for a destroy operator is *random removal*, which randomly destroys some part of the current solution.
-A good repair operator is *greedy repair*, which repairs the partially destroyed solution in a greedy manner.
-
 .. hint::
 
-    Now that you know a little more about the ideas behind ALNS, the :doc:`quickstart code template <template>` is a great place to get started using the ``alns`` package!
+    The :doc:`quickstart code template <template>` explains how to implement these in the format ``alns`` expects.

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -22,10 +22,7 @@ ALNS is one such heuristic method.
 
     :ref:`/examples/travelling_salesman_problem.ipynb` solves a TSP instance using ALNS.
 
-ALNS
-----
-
-The adaptive large neighbourhood search (ALNS) metaheuristic is:
+Specifically, the adaptive large neighbourhood search metaheuristic is:
 
 * A large neighbourhood search (LNS) method.
   LNS methods explore large subsets of the search space in a systematic manner.
@@ -40,6 +37,22 @@ The adaptive large neighbourhood search (ALNS) metaheuristic is:
 ALNS begins with an initial solution and then iterates until a stopping criterion is met.
 In each iteration, a destroy and repair operator are selected, which transform the current solution into a candidate solution.
 This candidate solution is then evaluated by an acceptance criterion, and the operator selection scheme is updated based on the evaluation outcome.
+In pseudocode, ALNS works as follows:
+
+    .. line-block::
+
+        **Input:** an initial solution :math:`s`
+        **Output:** optimised solution :math:`s^*`
+        :math:`s^* \gets s`
+        **repeat** until stopping criteria is met:
+            Select destroy and repair operator pair :math:`(d, r)` using operator selection scheme
+            :math:`s^c \gets r(d(s))`
+            **if** candidate is accepted:
+                :math:`s \gets s^c`
+            **if** :math:`s^c` has a better objective value than :math:`s^*`:
+                :math:`s^* \gets s^c`
+            Update operator selection scheme
+        **return** :math:`s^*`
 
 The ``alns`` package provides the ALNS algorithm, stopping and acceptance criteria, and various operator selection schemes for you.
 You need to provide:
@@ -48,7 +61,8 @@ You need to provide:
 * One or more destroy and repair operators tailored to your problem.
 
 Typically, a good start for a destroy operator is *random removal*, which randomly destroys some part of the current solution.
-A good repair operator is *greedy repair*, which then repairs the partially destroyed solution in a greedy manner.
+A good repair operator is *greedy repair*, which repairs the partially destroyed solution in a greedy manner.
 
-Now that you know a little more about the ideas behind ALNS, the :doc:`quickstart code template <template>` is a great place to get started using the ``alns`` package!
+.. hint::
 
+    Now that you know a little more about the ideas behind ALNS, the :doc:`quickstart code template <template>` is a great place to get started using the ``alns`` package!

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -16,7 +16,7 @@ Finding an *optimal* solution, however, can be very difficult since there are :m
 
 .. note::
 
-    :ref:`This example notebooks </examples/travelling_salesman_problem.ipynb>` solves a TSP instance using ALNS.
+    :ref:`This example notebook </examples/travelling_salesman_problem.ipynb>` solves a TSP instance using ALNS.
 
 Due to the explosive growth of the search space, most combinatorial problems cannot be solved optimally by testing every solution in the search space.
 For these problems, a heuristic method can help find good (but not necessarily optimal) solutions quickly.

--- a/docs/source/setup/introduction_to_alns.rst
+++ b/docs/source/setup/introduction_to_alns.rst
@@ -1,4 +1,54 @@
 A brief introduction to ALNS
 ============================
 
-TODO
+Before we explain what ALNS is, we first need to describe the type of problems it can solve well.
+These problems typically come from the field of `combinatorial optimisation <https://en.wikipedia.org/wiki/Combinatorial_optimization>`_, and have
+
+* A large (but finite) set of solutions (the *search space*)
+* An objective to be optimised by finding a *good* solution in the search space
+
+A very well-known example of such a problem is the `travelling salesman problem <https://en.wikipedia.org/wiki/Travelling_salesman_problem>`_ (TSP), which asks
+
+    Given a list of :math:`n` cities and the distances between each pair of cities, what is the shortest possible route that visits each city exactly once and returns to the origin city?
+
+It is easy to find *a* solution: :math:`1 \rightarrow 2 \rightarrow 3 \rightarrow \ldots \rightarrow n \rightarrow 1` is one option.
+Finding an *optimal* solution, however, can be very difficult since there are :math:`n!` possible solutions, and the search space thus grows very quickly with :math:`n`.
+
+Because of the explosive growth of the search space, combinatorial problems cannot be solved optimally by testing every solution in the search space.
+In such cases, a heuristic method can help find good (but not necessarily optimal) solutions quickly.
+ALNS is one such heuristic method.
+
+.. note::
+
+    :ref:`/examples/travelling_salesman_problem.ipynb` solves a TSP instance using ALNS.
+
+ALNS
+----
+
+The adaptive large neighbourhood search (ALNS) metaheuristic is:
+
+* A large neighbourhood search (LNS) method.
+  LNS methods explore large subsets of the search space in a systematic manner.
+
+* A *meta* heuristic.
+  Metaheuristics use other heuristics as operators.
+  ALNS, in particular, is a ruin-and-recreate algorithm: it relies on heuristic *destroy* and *repair* operators to explore the search space.
+
+* Adaptive.
+  During the search, ALNS learns about operators that are more effective than others, and uses that information to choose those effective operators more often.
+
+ALNS begins with an initial solution and then iterates until a stopping criterion is met.
+In each iteration, a destroy and repair operator are selected, which transform the current solution into a candidate solution.
+This candidate solution is then evaluated by an acceptance criterion, and the operator selection scheme is updated based on the evaluation outcome.
+
+The ``alns`` package provides the ALNS algorithm, stopping and acceptance criteria, and various operator selection schemes for you.
+You need to provide:
+
+* An initial solution.
+* One or more destroy and repair operators tailored to your problem.
+
+Typically, a good start for a destroy operator is *random removal*, which randomly destroys some part of the current solution.
+A good repair operator is *greedy repair*, which then repairs the partially destroyed solution in a greedy manner.
+
+Now that you know a little more about the ideas behind ALNS, the :doc:`quickstart code template <template>` is a great place to get started using the ``alns`` package!
+

--- a/docs/source/setup/template.rst
+++ b/docs/source/setup/template.rst
@@ -83,7 +83,7 @@ The following is a quickstart template that can help you get started:
     best = result.best_state
     print(f"Best heuristic solution objective is {best.objective()}.")
 
-.. note::
+.. hint::
 
     Have a look at the examples to get a feeling for how to implement the TODOs
     in the quickstart template!

--- a/docs/source/setup/template.rst
+++ b/docs/source/setup/template.rst
@@ -13,6 +13,9 @@ You should provide the following:
   operator should copy the passed-in state; see
   :meth:`~alns.ALNS.ALNS.add_destroy_operator` for details.
 
+Typically, a good first destroy operator is *random removal*, which randomly destroys some part of the current solution.
+A good first repair operator is *greedy repair*, which repairs the partially destroyed solution in a greedy manner.
+
 .. note::
 
    The ``alns`` package assumes your problem is a minimisation problem. If you


### PR DESCRIPTION
Written in https://github.com/openjournals/joss-reviews/issues/5028:

> [..] improving the help for non-OR users to bring their own problems into ALNS. This could make the library much more accessible to a wider audience. The code quickstart suggested by @skadio and the [ALNS features](https://alns.readthedocs.io/en/latest/examples/alns_features.html) page are good places to start, but I would have really appreciated an introduction to ALNS and some more general help (eg what problems it is good for, how to apply ALNS to your own problem, what is necessary to implement, how important different parts are).

Our response to this has been:

>I will write another page in the documentation explicitly introducing ALNS, explaining what type of problems it can be used to solve, and briefly describe what a minimal implementation should contain (in terms of ideas). This complements the quick start template, which is really about "so how do I turn those ideas into code". I expect I will have this finished later today, and will report back then.

And this PR adds the promised page to the documentation.
